### PR TITLE
fix(#21): switch Higgs default attention to SDPA; make flash-attn optional on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ The STT validation (`tests/stt_validate.py`) serves dual purpose: it checks tran
 - `AVAILABLE_VRAM_MB` — VRAM budget in MB (default 12000). Recommended: 10000.
 - `TTS_VOICES_DIR` — voice storage directory (default ./voices)
 - `HIGGS_QUANT_BITS` — quantization bits for higgs (4, 8, or 0 for bf16)
-- `HIGGS_ATTN_IMPL` — attention implementation for higgs (`flash_attention_2` default, `sdpa`, or `eager`). `flash_attention_2` requires `flash_attn` which is installed automatically by `scripts/setup_venvs.sh`. `sdpa` uses torch's built-in SDPA kernel (no extra packages — fallback if flash_attn build fails).
+- `HIGGS_ATTN_IMPL` — attention implementation for higgs (`sdpa` default, `flash_attention_2`, or `eager`). `flash_attention_2` requires `flash_attn` which does not build from source on Windows (CUTLASS/MSVC incompatibility); leave unset unless you have a pre-built wheel. `sdpa` uses torch's built-in SDPA kernel (no extra packages).
 - `HIGGS_REPO_PATH` — path to faster-higgs-audio repo (default %USERPROFILE%\tmp\faster-higgs-audio)
 - `HIGGS_WORKER_PYTHON` — override the Python interpreter used for the higgs subprocess worker (default: `.venvs/higgs/Scripts/python.exe` on Windows, `/workspaces/.venvs/tts_server-higgs/bin/python` on Linux)
 - `CB_WORKER_PYTHON` — override the Python interpreter used for the chatterbox subprocess worker (default: `.venvs/chatterbox/Scripts/python.exe` on Windows, `/workspaces/.venvs/tts_server-chatterbox/bin/python` on Linux)

--- a/app/main.py
+++ b/app/main.py
@@ -11,12 +11,9 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
 import numpy as np
 import soundfile as sf
+from dotenv import load_dotenv
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import Response
 from loguru import logger
@@ -34,6 +31,8 @@ from app.voices import (
     VoiceStore,
     _slugify,
 )
+
+load_dotenv()
 
 
 class InterceptHandler(logging.Handler):

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,10 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import numpy as np
 import soundfile as sf
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile

--- a/app/main.py
+++ b/app/main.py
@@ -19,20 +19,22 @@ from fastapi.responses import Response
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from app.engine_chatterbox import ChatterboxEngine
-from app.engine_chatterbox_full import ChatterboxFullEngine
-from app.engine_higgs import HiggsEngine
-from app.engine_qwen3 import Qwen3Engine
-from app.model_manager import ModelManager
-from app.voices import (
+# load_dotenv() must run before app.* imports: engine files read os.environ at module level
+# (HIGGS_QUANT_BITS, HIGGS_WORKER_PYTHON, QWEN3_MODEL_ID, etc. are module-level constants).
+load_dotenv()
+
+from app.engine_chatterbox import ChatterboxEngine  # noqa: E402
+from app.engine_chatterbox_full import ChatterboxFullEngine  # noqa: E402
+from app.engine_higgs import HiggsEngine  # noqa: E402
+from app.engine_qwen3 import Qwen3Engine  # noqa: E402
+from app.model_manager import ModelManager  # noqa: E402
+from app.voices import (  # noqa: E402
     DEFAULT_MAX_DURATION_S,
     VoiceListResponse,
     VoiceMetadata,
     VoiceStore,
     _slugify,
 )
-
-load_dotenv()
 
 
 class InterceptHandler(logging.Handler):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "soundfile>=0.12",
     "numpy>=1.24",
     "scipy>=1.10",
+    "python-dotenv>=1.0",
 ]
 
 [project.scripts]

--- a/scripts/setup_venvs.ps1
+++ b/scripts/setup_venvs.ps1
@@ -156,6 +156,20 @@ Write-Host ""
 if ($anyFailed) {
     Write-Host "==> Some installs failed. Check output above."
     exit 1
-} else {
-    Write-Host "==> All venvs ready. Start with: .\start_server.ps1"
 }
+
+# ---------------------------------------------------------------------------
+# Step 4: Install flash-attn into the higgs venv (must run after torch is ready).
+# --no-build-isolation lets it link against the already-installed torch headers.
+# ---------------------------------------------------------------------------
+Write-Host "--- Installing flash-attn into higgs venv (compiles from source, ~5-10 min) ---"
+$HiggsPip = Join-Path $HiggsVenv "Scripts\pip.exe"
+$faResult = & $HiggsPip install flash-attn --no-build-isolation 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[warn] flash-attn build failed — Higgs will fall back to SDPA attention"
+    Write-Host "       Details: $($faResult | Select-Object -Last 5 | Out-String)"
+} else {
+    Write-Host "[ok]   flash-attn installed"
+}
+Write-Host ""
+Write-Host "==> All venvs ready. Start with: .\start_server.ps1"

--- a/tests/profile_fa2_higgs.py
+++ b/tests/profile_fa2_higgs.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import base64
 import json
 import os
-import struct
 import subprocess
 import sys
 import time
@@ -112,8 +111,6 @@ def _run_one(attn_impl: str, out_path: Path, env: dict[str, str]) -> dict[str, f
     worker_env = {**os.environ, **env, "HIGGS_ATTN_IMPL": attn_impl, "HIGGS_QUANT_BITS": "4"}
 
     print(f"\n[{attn_impl}] Starting worker...")
-    t_start = time.monotonic()
-
     proc = subprocess.Popen(
         [str(WORKER_PYTHON), str(WORKER_SCRIPT)],
         stdin=subprocess.PIPE,

--- a/tests/profile_fa2_higgs.py
+++ b/tests/profile_fa2_higgs.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Profile Flash Attention 2 vs SDPA on 4-bit Higgs.
+
+Spawns the higgs worker directly (no HTTP server needed) with each attention
+implementation, measures load + generation time, and saves both WAV files to
+tests/samples/ for human listening comparison.
+
+Usage (from repo root, host venv active):
+    python tests/profile_fa2_higgs.py
+
+Output:
+    tests/samples/higgs_4bit_sdpa.wav
+    tests/samples/higgs_4bit_fa2.wav
+    Timing table printed to stdout.
+
+Requirements:
+    - .venvs/higgs/  set up (run scripts/setup_venvs.ps1 first)
+    - flash-attn installed in higgs venv (setup_venvs.ps1 Step 4)
+    - .env present with HIGGS_REPO_PATH / HIGGS_MODEL_ID
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import scipy.io.wavfile as wavfile
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLES_DIR = REPO_ROOT / "tests" / "samples"
+WORKER_SCRIPT = REPO_ROOT / "workers" / "higgs_worker.py"
+WORKER_PYTHON = REPO_ROOT / ".venvs" / "higgs" / "Scripts" / "python.exe"
+
+# ~10 second fixture text (≈130 words/min rate → ~25 words ≈ 10-12 s of audio)
+FIXTURE_TEXT = (
+    "The old lighthouse stood at the edge of the rocky coast, "
+    "its beam sweeping steadily across the dark waters as storm clouds "
+    "gathered on the horizon. Sailors had relied on its light for generations."
+)
+
+ATTN_RUNS = [
+    ("sdpa",              "higgs_4bit_sdpa.wav"),
+    ("flash_attention_2", "higgs_4bit_fa2.wav"),
+]
+
+
+# ---------------------------------------------------------------------------
+# .env loader (stdlib only — host venv has no python-dotenv)
+# ---------------------------------------------------------------------------
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        env[k.strip()] = v.strip()
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Worker IPC helpers
+# ---------------------------------------------------------------------------
+
+def _send(proc: subprocess.Popen, payload: dict) -> None:
+    line = (json.dumps(payload) + "\n").encode()
+    proc.stdin.write(line)
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout: float = 300.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while True:
+        if time.monotonic() > deadline:
+            raise TimeoutError("Worker did not respond within timeout")
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("Worker stdout closed unexpectedly")
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("status") == "error":
+            raise RuntimeError(
+                f"Worker error: {msg.get('message')} | {msg.get('traceback', '')[:500]}"
+            )
+        return msg
+
+
+def _save_wav(path: Path, audio_b64: str, sample_rate: int) -> None:
+    audio_bytes = base64.b64decode(audio_b64)
+    audio = np.frombuffer(audio_bytes, dtype=np.float32)
+    # scipy expects int16 or float32; write as float32 WAV
+    wavfile.write(str(path), sample_rate, audio)
+
+
+# ---------------------------------------------------------------------------
+# Single profiling run
+# ---------------------------------------------------------------------------
+
+def _run_one(attn_impl: str, out_path: Path, env: dict[str, str]) -> dict[str, float]:
+    """Spawn the higgs worker with the given attn impl, run one generate, return timings."""
+    worker_env = {**os.environ, **env, "HIGGS_ATTN_IMPL": attn_impl, "HIGGS_QUANT_BITS": "4"}
+
+    print(f"\n[{attn_impl}] Starting worker...")
+    t_start = time.monotonic()
+
+    proc = subprocess.Popen(
+        [str(WORKER_PYTHON), str(WORKER_SCRIPT)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,  # stream worker logs to our stderr
+        env=worker_env,
+        cwd=str(REPO_ROOT),
+    )
+
+    # Load model
+    print(f"[{attn_impl}] Loading model (4-bit)...")
+    t_load_start = time.monotonic()
+    _send(proc, {"cmd": "load"})
+    _recv(proc, timeout=300.0)
+    t_load_end = time.monotonic()
+    load_time = t_load_end - t_load_start
+    print(f"[{attn_impl}] Load done in {load_time:.1f}s")
+
+    # Generate
+    print(f"[{attn_impl}] Generating audio...")
+    t_gen_start = time.monotonic()
+    _send(proc, {"cmd": "generate", "text": FIXTURE_TEXT, "params": {}})
+    resp = _recv(proc, timeout=300.0)
+    t_gen_end = time.monotonic()
+    gen_time = t_gen_end - t_gen_start
+    print(f"[{attn_impl}] Generate done in {gen_time:.1f}s")
+
+    # Save WAV
+    SAMPLES_DIR.mkdir(parents=True, exist_ok=True)
+    _save_wav(out_path, resp["audio"], resp["sample_rate"])
+    audio_duration = len(base64.b64decode(resp["audio"])) / 4 / resp["sample_rate"]
+    print(f"[{attn_impl}] Saved {out_path.name}  ({audio_duration:.1f}s audio)")
+
+    # Unload + shutdown
+    _send(proc, {"cmd": "unload"})
+    proc.wait(timeout=30)
+
+    return {
+        "load_s": load_time,
+        "gen_s": gen_time,
+        "audio_s": audio_duration,
+        "rtf": gen_time / audio_duration if audio_duration > 0 else float("nan"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    dotenv = _load_dotenv(REPO_ROOT / ".env")
+
+    if not WORKER_PYTHON.exists():
+        sys.exit(f"ERROR: higgs venv not found at {WORKER_PYTHON}\nRun scripts/setup_venvs.ps1 first.")
+
+    results: list[tuple[str, str, dict]] = []
+    for attn_impl, filename in ATTN_RUNS:
+        out_path = SAMPLES_DIR / filename
+        try:
+            timings = _run_one(attn_impl, out_path, dotenv)
+            results.append((attn_impl, str(out_path), timings))
+        except Exception as exc:
+            print(f"\n[ERROR] {attn_impl} run failed: {exc}", file=sys.stderr)
+            results.append((attn_impl, str(out_path), {"error": str(exc)}))
+
+    # Summary table
+    print("\n" + "=" * 65)
+    print(f"{'Attention':<22} {'Load':>7} {'Generate':>10} {'Audio':>7} {'RTF':>6}")
+    print("-" * 65)
+    for attn_impl, path, t in results:
+        if "error" in t:
+            print(f"{attn_impl:<22}  ERROR: {t['error']}")
+        else:
+            print(
+                f"{attn_impl:<22} {t['load_s']:>6.1f}s {t['gen_s']:>9.1f}s "
+                f"{t['audio_s']:>6.1f}s {t['rtf']:>5.2f}x"
+            )
+    print("=" * 65)
+    print("RTF = generate_time / audio_duration  (lower is faster)")
+    print()
+    print("Output WAVs for human review:")
+    for _, path, t in results:
+        if "error" not in t:
+            print(f"  {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/higgs_worker.py
+++ b/workers/higgs_worker.py
@@ -51,7 +51,7 @@ else:
 # "flash_attention_2" requires flash_attn (installed by scripts/setup_venvs.sh).
 # "sdpa" uses torch's built-in scaled_dot_product_attention — no extra packages.
 _VALID_ATTN_IMPLS = {"flash_attention_2", "sdpa", "eager"}
-ATTN_IMPL = os.environ.get("HIGGS_ATTN_IMPL", "flash_attention_2").strip().lower()
+ATTN_IMPL = os.environ.get("HIGGS_ATTN_IMPL", "sdpa").strip().lower()
 
 DEFAULT_SCENE = "Audio is recorded from a quiet room."
 

--- a/workers/higgs_worker.py
+++ b/workers/higgs_worker.py
@@ -48,7 +48,7 @@ else:
     QUANTIZATION_BITS = int(_raw_quant)
 
 # Attention implementation: "flash_attention_2" (default), "sdpa", or "eager".
-# "flash_attention_2" requires flash_attn (installed by scripts/setup_venvs.sh).
+# "flash_attention_2" requires flash_attn (optional install in scripts/setup_venvs.ps1 Step 4).
 # "sdpa" uses torch's built-in scaled_dot_product_attention — no extra packages.
 _VALID_ATTN_IMPLS = {"flash_attention_2", "sdpa", "eager"}
 ATTN_IMPL = os.environ.get("HIGGS_ATTN_IMPL", "sdpa").strip().lower()


### PR DESCRIPTION
## Summary

- Switch `HIGGS_ATTN_IMPL` default from `flash_attention_2` → `sdpa` — `flash_attn` cannot be built from source on Windows (CUTLASS/MSVC incompatibility)
- `scripts/setup_venvs.ps1`: add Step 4 that attempts `flash-attn` install in the higgs venv with graceful fallback warning if the build fails
- `app/main.py`: add `load_dotenv()` at startup so `.env` is picked up automatically; add `python-dotenv>=1.0` to host dependencies
- `tests/profile_fa2_higgs.py`: new profiling script to benchmark FA2 vs SDPA load + generation time side-by-side

Closes #21
Part of #15 (`torch.compile` investigation remains open)

## Test plan

- [ ] Start server on Windows — confirm no import error from `python-dotenv`
- [ ] Confirm `HIGGS_ATTN_IMPL` defaults to `sdpa` when env var is unset
- [ ] Run `scripts/setup_venvs.ps1` — confirm Step 4 flash-attn build attempt prints warning on failure without aborting setup
- [ ] (Optional) Run `python tests/profile_fa2_higgs.py` with higgs venv set up to compare FA2 vs SDPA timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)